### PR TITLE
[ECS-05] add unit with adding MoveSpeed Component

### DIFF
--- a/.github/workflows/default_comment.yaml
+++ b/.github/workflows/default_comment.yaml
@@ -31,4 +31,3 @@ jobs:
 
             _This message was posted automatically._
           comment-id: boilerplate-comment
-          edit-mode: nothing

--- a/Assets/Scenes/GameScene/EntitiesSubScene.unity
+++ b/Assets/Scenes/GameScene/EntitiesSubScene.unity
@@ -250,7 +250,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 02ffdcc9672641909e880edd89af6b44, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  value: 56
+  value: 2
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/GameScene/EntitiesSubScene.unity
+++ b/Assets/Scenes/GameScene/EntitiesSubScene.unity
@@ -119,7 +119,140 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &359665584
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 359665585}
+  - component: {fileID: 359665587}
+  - component: {fileID: 359665586}
+  m_Layer: 0
+  m_Name: Mesh
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &359665585
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 359665584}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2036580992}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &359665586
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 359665584}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 0ed9a8419c3ed6c4d812c63c5f587e5f, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &359665587
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 359665584}
+  m_Mesh: {fileID: 4300000, guid: b628a2a6897ec8b42b9f10a4630a496e, type: 2}
+--- !u!1 &2036580991
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2036580992}
+  - component: {fileID: 2036580993}
+  m_Layer: 0
+  m_Name: Unit
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2036580992
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2036580991}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 359665585}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2036580993
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2036580991}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 02ffdcc9672641909e880edd89af6b44, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  value: 56
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
-  m_Roots: []
+  m_Roots:
+  - {fileID: 2036580992}

--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f517f145a3ee0e54e9be551bb37e2139
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Authoring.meta
+++ b/Assets/Scripts/Authoring.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bdec0dce267a2184282529730d4701f3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Authoring/MoveSpeedAuthoring.cs
+++ b/Assets/Scripts/Authoring/MoveSpeedAuthoring.cs
@@ -1,0 +1,24 @@
+using Unity.Entities;
+using UnityEngine;
+
+public class MoveSpeedAuthoring : MonoBehaviour
+{
+    public float value;
+
+    public class Baker : Baker<MoveSpeedAuthoring>
+    {
+        public override void Bake(MoveSpeedAuthoring authoring)
+        {
+            Entity entity = GetEntity(TransformUsageFlags.Dynamic);
+            AddComponent(entity, new MoveSpeed
+            {
+                value = authoring.value
+            });
+        }
+    }
+}
+
+public struct MoveSpeed : IComponentData
+{
+    public float value;
+}

--- a/Assets/Scripts/Authoring/MoveSpeedAuthoring.cs.meta
+++ b/Assets/Scripts/Authoring/MoveSpeedAuthoring.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 02ffdcc9672641909e880edd89af6b44
+timeCreated: 1746433146

--- a/Assets/Scripts/Systems.meta
+++ b/Assets/Scripts/Systems.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d950fc4a74a41b84b8c2c2d2f2369f8f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Systems/UnitMoverSystem.cs
+++ b/Assets/Scripts/Systems/UnitMoverSystem.cs
@@ -1,0 +1,28 @@
+using Unity.Burst;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+partial struct UnitMoverSystem : ISystem
+{
+    [BurstCompile]
+    public void OnCreate(ref SystemState state)
+    {
+        
+    }
+
+    [BurstCompile]
+    public void OnUpdate(ref SystemState state)
+    {
+        foreach ((RefRW<LocalTransform> localTransform, RefRO<MoveSpeed> moveSpeed) in SystemAPI.Query<RefRW<LocalTransform>, RefRO<MoveSpeed>>())
+        {
+            localTransform.ValueRW.Position = localTransform.ValueRO.Position + new float3(moveSpeed.ValueRO.value, 0, 0) * SystemAPI.Time.DeltaTime;
+        }
+    }
+
+    [BurstCompile]
+    public void OnDestroy(ref SystemState state)
+    {
+        
+    }
+}

--- a/Assets/Scripts/Systems/UnitMoverSystem.cs.meta
+++ b/Assets/Scripts/Systems/UnitMoverSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: de66df79ba8c27f468fb391664921a1a

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Lesson - 02, Import Assets into Games
 ![Screenshot 2025-05-01 064420](https://github.com/user-attachments/assets/fde816cf-5d8b-4dc1-a916-02d39088b9cc)
 
 - Create a new Scene (GamaScene.scene) and add the ground, add the Player and Zombie
-
 - Removed assets which comes default with unity Projects
+
 <img width="354" alt="image" src="https://github.com/user-attachments/assets/67968259-4403-41cf-9b9d-f5b3cb1e0713" />
 
 Lesson - 03, Post Processing and Lighting settings
@@ -45,6 +45,23 @@ Lesson - 03, Post Processing and Lighting settings
 
 Lesson - 04, Subscene Baking
 ==================================================================
+- (Branch - https://github.com/gauravgitlab/ECS/tree/features/04_dots_subscene_baking)
+- (PR - https://github.com/gauravgitlab/ECS/pull/4)
 - Learn basic understanding of Baking
 - change Entities settings in Preference
     -- Set `Scene View Mode` to `RunTime Data`
+
+<img width="520" alt="image" src="https://github.com/user-attachments/assets/64199b6d-5f22-4675-9c6f-8ebc102ec11c" />
+
+Lesson - 05, 
+==================================================================
+- (Branch - https://github.com/gauravgitlab/ECS/tree/features/05_create_component_and_unit_setup)
+- (PR - https://github.com/gauravgitlab/ECS/pull/5)
+- Add Unit with Component and System with following steps
+- Add the new empty gameobject in Entity SubScene.
+- Name it Unit, This gameobject is only holding data component.
+- create another empty gameobject as a child inside Unit gameobject and named it as Mesh
+- Create new Monobehavior class, called MoveSpeedAuthoring
+- Attach this script with Unit gameobject
+- Create new Script inherit from ISytem.
+


### PR DESCRIPTION
### Description
- Add the new empty gameobject in Entity SubScene. 
- Name it `Unit`, This gameobject is only holding data component.
- create another empty gameobject as a child inside `Unit` gameobject and named it as `Mesh`
- Create new Monobehavior class, called `MoveSpeedAuthoring`
- Attach this script with `Unit` gameobject
- Create new Script inherit from ISytem.


### Screenshots
<img width="836" alt="image" src="https://github.com/user-attachments/assets/f1294035-d36a-44fb-a1a4-177758214f06" />
