### PR TITLE
[ECS-06] Move Unit using Physics and Mouse World Position

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -479,6 +479,50 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &838261184
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 838261186}
+  - component: {fileID: 838261185}
+  m_Layer: 0
+  m_Name: MouseWorldPosition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &838261185
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 838261184}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a388df63b10524b47a372615bb388ce0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &838261186
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 838261184}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1225399846
 GameObject:
   m_ObjectHideFlags: 0
@@ -596,4 +640,5 @@ SceneRoots:
   - {fileID: 410087041}
   - {fileID: 832575519}
   - {fileID: 1225399850}
+  - {fileID: 838261186}
   - {fileID: 295806491}

--- a/Assets/Scenes/GameScene/EntitiesSubScene.unity
+++ b/Assets/Scenes/GameScene/EntitiesSubScene.unity
@@ -215,6 +215,8 @@ GameObject:
   m_Component:
   - component: {fileID: 2036580992}
   - component: {fileID: 2036580993}
+  - component: {fileID: 2036580995}
+  - component: {fileID: 2036580994}
   m_Layer: 0
   m_Name: Unit
   m_TagString: Untagged
@@ -251,6 +253,56 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   value: 2
+--- !u!54 &2036580994
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2036580991}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 1
+  m_Constraints: 116
+  m_CollisionDetection: 0
+--- !u!136 &2036580995
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2036580991}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 1.1, z: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/MonoBehaviour.meta
+++ b/Assets/Scripts/MonoBehaviour.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fcb136c8db29c4e47899d50bcec2c8b7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MonoBehaviour/MouseWorldPosition.cs
+++ b/Assets/Scripts/MonoBehaviour/MouseWorldPosition.cs
@@ -1,0 +1,33 @@
+using System;
+using UnityEngine;
+
+public class MouseWorldPostion : MonoBehaviour
+{
+    public static MouseWorldPostion Instance { get; private set; }
+
+    private void Awake()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    public Vector3 GetPosition()
+    {
+        Ray mouseCameraRay = Camera.main.ScreenPointToRay(Input.mousePosition);
+        Plane plane = new Plane(Vector3.up, Vector3.zero);
+        
+        if (plane.Raycast(mouseCameraRay, out float distance))
+        {
+            return mouseCameraRay.GetPoint(distance);
+        }
+        
+        return Vector3.zero;
+    }
+}

--- a/Assets/Scripts/MonoBehaviour/MouseWorldPosition.cs.meta
+++ b/Assets/Scripts/MonoBehaviour/MouseWorldPosition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a388df63b10524b47a372615bb388ce0

--- a/Assets/Scripts/Systems/UnitMoverSystem.cs
+++ b/Assets/Scripts/Systems/UnitMoverSystem.cs
@@ -1,6 +1,7 @@
 using Unity.Burst;
 using Unity.Entities;
 using Unity.Mathematics;
+using Unity.Physics;
 using Unity.Transforms;
 
 partial struct UnitMoverSystem : ISystem
@@ -14,9 +15,17 @@ partial struct UnitMoverSystem : ISystem
     [BurstCompile]
     public void OnUpdate(ref SystemState state)
     {
-        foreach ((RefRW<LocalTransform> localTransform, RefRO<MoveSpeed> moveSpeed) in SystemAPI.Query<RefRW<LocalTransform>, RefRO<MoveSpeed>>())
+        foreach ((RefRW<LocalTransform> localTransform, RefRO<MoveSpeed> moveSpeed, RefRW<PhysicsVelocity> physicsVelocity) in 
+                 SystemAPI.Query<RefRW<LocalTransform>, RefRO<MoveSpeed>, RefRW<PhysicsVelocity>>())
         {
-            localTransform.ValueRW.Position = localTransform.ValueRO.Position + new float3(moveSpeed.ValueRO.value, 0, 0) * SystemAPI.Time.DeltaTime;
+            float3 targetPosition = MouseWorldPostion.Instance.GetPosition();
+            float3 moveDirection = targetPosition - localTransform.ValueRO.Position;
+            moveDirection = math.normalize(moveDirection);
+            
+            localTransform.ValueRW.Rotation = quaternion.LookRotation(moveDirection, math.up());
+            physicsVelocity.ValueRW.Linear = moveDirection * moveSpeed.ValueRO.value;
+            physicsVelocity.ValueRW.Angular = float3.zero;
+            //localTransform.ValueRW.Position += moveDirection * moveSpeed.ValueRO.value * SystemAPI.Time.DeltaTime;
         }
     }
 

--- a/Assets/Scripts/Systems/UnitMoverSystem.cs
+++ b/Assets/Scripts/Systems/UnitMoverSystem.cs
@@ -21,11 +21,12 @@ partial struct UnitMoverSystem : ISystem
             float3 targetPosition = MouseWorldPostion.Instance.GetPosition();
             float3 moveDirection = targetPosition - localTransform.ValueRO.Position;
             moveDirection = math.normalize(moveDirection);
-            
-            localTransform.ValueRW.Rotation = quaternion.LookRotation(moveDirection, math.up());
+
+            float rotationSpeed = SystemAPI.Time.DeltaTime * 10.0f;
+            localTransform.ValueRW.Rotation = math.slerp(localTransform.ValueRO.Rotation, 
+                quaternion.LookRotation(moveDirection, math.up()), rotationSpeed);
             physicsVelocity.ValueRW.Linear = moveDirection * moveSpeed.ValueRO.value;
             physicsVelocity.ValueRW.Angular = float3.zero;
-            //localTransform.ValueRW.Position += moveDirection * moveSpeed.ValueRO.value * SystemAPI.Time.DeltaTime;
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Lesson - 04, Subscene Baking
 
 <img width="520" alt="image" src="https://github.com/user-attachments/assets/64199b6d-5f22-4675-9c6f-8ebc102ec11c" />
 
-Lesson - 05, 
+Lesson - 05, Create component and Unit Setup
 ==================================================================
 - (Branch - https://github.com/gauravgitlab/ECS/tree/features/05_create_component_and_unit_setup)
 - (PR - https://github.com/gauravgitlab/ECS/pull/5)
@@ -66,4 +66,18 @@ Lesson - 05,
 - Create new Script inherit from ISytem.
 
 ![image](https://github.com/user-attachments/assets/09441a7a-ad71-43b4-b292-afebfc6eb51c)
+
+Lesson - 06, Move Unit using Physics and Mouse World Position
+==================================================================
+- (Branch - https://github.com/gauravgitlab/ECS/tree/features/06_unit_move_physics)
+- (PR - https://github.com/gauravgitlab/ECS/pull/6)
+- Move Unit using Physics
+- In `UnitMoverSystem.cs`, we use `PhysicsVelocity` to move the unit linearly.
+- we applied the `capsule collider` and `Rigidbody` to the unit.
+Note - the ECS physics works completely different to Normal Gameobject Physics, so it won't interact with each other.
+
+- Mouse World Position
+- we add the Monobehavoiur scrpit `MouseWorldPosition.cs` and make it singleton which returns the Mouse Position
+- Create Empty gameobject and attach the scrpit `MouseWorldPosition.cs`
+- Use the MouseWorldPosition in `UnitMoveSystem.cs` to move and rotate the unit.
 


### PR DESCRIPTION
### Description of Changes <!-- required -->
-  Move Unit using Physics
- In `UnitMoverSystem.cs`, we use `PhysicsVelocity` to move the unit linearly.
- we applied the `capsule collider` and `Rigidbody` to the unit.
Note - the ECS physics works completely different to Normal Gameobject Physics, so it won't interact with each other.

- Mouse World Position
- we add the Monobehavoiur scrpit `MouseWorldPosition.cs` and make it singleton which returns the Mouse Position
- Create Empty gameobject and attach the scrpit `MouseWorldPosition.cs`
- Use the MouseWorldPosition in `UnitMoveSystem.cs` to move and rotate the unit.

### Screenshot/Gif/Video of Changes <!-- delete this section if change is not visible -->
- Add Collider and Rigidbody in Unit
![Screenshot 2025-05-07 073034](https://github.com/user-attachments/assets/09fce4ff-b963-4426-ae13-a6266129c47f)


- Move Unit Using Math
![Screenshot 2025-05-07 073016](https://github.com/user-attachments/assets/5685ed14-3037-42d4-963b-ac5ae8a46b38)

- Move Unit using Mouse Position
<img width="768" alt="Screenshot 2025-05-07 224505" src="https://github.com/user-attachments/assets/a426b0ea-0725-40cf-ab34-7ef6e0f943b5" />

This is an automated comment to help with consistency:
- [x] Ensure your PR has a clear title and meaningful description.
- [x] Confirm all relevant tests are added or updated.
- [x] Assign labels if applicable.
- [x] Link related issues or discussions.

_This message was posted automatically._