### PR TITLE
[ECS-15] Adding the health Component in Unit

### DIFF
--- a/Assets/Prefabs/BaseUnit.prefab
+++ b/Assets/Prefabs/BaseUnit.prefab
@@ -97,9 +97,11 @@ GameObject:
   - component: {fileID: 8530267801777748712}
   - component: {fileID: 3474872740883573309}
   - component: {fileID: -3192969502012937948}
+  - component: {fileID: 1651913212507342374}
+  - component: {fileID: 8933043106874728651}
+  - component: {fileID: 79178318199922201}
   - component: {fileID: 1935549530865082562}
   - component: {fileID: 7021448735307608125}
-  - component: {fileID: 79178318199922201}
   m_Layer: 6
   m_Name: BaseUnit
   m_TagString: Untagged
@@ -150,6 +152,43 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   faction: 0
+--- !u!114 &1651913212507342374
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6604268163913019920}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1c220cec5d8ca6b46b5f06d205e76dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8933043106874728651
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6604268163913019920}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b336e2e421046e498eb2e3bfcfb8687, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  healthAmount: 100
+--- !u!114 &79178318199922201
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6604268163913019920}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c16549610bfe4458aa9389201d072bb6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!136 &1935549530865082562
 CapsuleCollider:
   m_ObjectHideFlags: 0
@@ -200,15 +239,3 @@ Rigidbody:
   m_Interpolate: 1
   m_Constraints: 116
   m_CollisionDetection: 0
---- !u!114 &79178318199922201
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6604268163913019920}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c16549610bfe4458aa9389201d072bb6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/BaseUnit.prefab
+++ b/Assets/Prefabs/BaseUnit.prefab
@@ -99,6 +99,7 @@ GameObject:
   - component: {fileID: -3192969502012937948}
   - component: {fileID: 1935549530865082562}
   - component: {fileID: 7021448735307608125}
+  - component: {fileID: 79178318199922201}
   m_Layer: 6
   m_Name: BaseUnit
   m_TagString: Untagged
@@ -148,6 +149,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 092a930f171decb4dbe457557c472be0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  faction: 0
 --- !u!136 &1935549530865082562
 CapsuleCollider:
   m_ObjectHideFlags: 0
@@ -198,3 +200,15 @@ Rigidbody:
   m_Interpolate: 1
   m_Constraints: 116
   m_CollisionDetection: 0
+--- !u!114 &79178318199922201
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6604268163913019920}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c16549610bfe4458aa9389201d072bb6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/SoldierUnit.prefab
+++ b/Assets/Prefabs/SoldierUnit.prefab
@@ -164,6 +164,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 6604268163913019920, guid: 1074344954d3b7643a55e2d4e4242946, type: 3}
       insertIndex: 7
       addedObject: {fileID: -1482368254612140831}
+    - targetCorrespondingSourceObject: {fileID: 6604268163913019920, guid: 1074344954d3b7643a55e2d4e4242946, type: 3}
+      insertIndex: 8
+      addedObject: {fileID: -1275936212795353050}
   m_SourcePrefab: {fileID: 100100000, guid: 1074344954d3b7643a55e2d4e4242946, type: 3}
 --- !u!1 &6627728850896468784 stripped
 GameObject:
@@ -236,6 +239,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   timerMax: 0.2
+--- !u!114 &-1275936212795353050
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6627728850896468784}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b336e2e421046e498eb2e3bfcfb8687, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  healthAmount: 100
 --- !u!4 &8519939681605153736 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8530267801777748712, guid: 1074344954d3b7643a55e2d4e4242946, type: 3}

--- a/Assets/Prefabs/SoldierUnit.prefab
+++ b/Assets/Prefabs/SoldierUnit.prefab
@@ -160,13 +160,7 @@ PrefabInstance:
       addedObject: {fileID: -2723765071603424257}
     - targetCorrespondingSourceObject: {fileID: 6604268163913019920, guid: 1074344954d3b7643a55e2d4e4242946, type: 3}
       insertIndex: 6
-      addedObject: {fileID: -1795131162095095857}
-    - targetCorrespondingSourceObject: {fileID: 6604268163913019920, guid: 1074344954d3b7643a55e2d4e4242946, type: 3}
-      insertIndex: 7
       addedObject: {fileID: -1482368254612140831}
-    - targetCorrespondingSourceObject: {fileID: 6604268163913019920, guid: 1074344954d3b7643a55e2d4e4242946, type: 3}
-      insertIndex: 8
-      addedObject: {fileID: -1275936212795353050}
   m_SourcePrefab: {fileID: 100100000, guid: 1074344954d3b7643a55e2d4e4242946, type: 3}
 --- !u!1 &6627728850896468784 stripped
 GameObject:
@@ -214,18 +208,6 @@ MonoBehaviour:
   range: 7
   targetFaction: 1
   timerMax: 0.2
---- !u!114 &-1795131162095095857
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6627728850896468784}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1c220cec5d8ca6b46b5f06d205e76dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &-1482368254612140831
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -239,19 +221,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   timerMax: 0.2
---- !u!114 &-1275936212795353050
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6627728850896468784}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b336e2e421046e498eb2e3bfcfb8687, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  healthAmount: 100
 --- !u!4 &8519939681605153736 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8530267801777748712, guid: 1074344954d3b7643a55e2d4e4242946, type: 3}

--- a/Assets/Prefabs/ZombieUnit.prefab
+++ b/Assets/Prefabs/ZombieUnit.prefab
@@ -81,6 +81,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 6604268163913019920, guid: 1074344954d3b7643a55e2d4e4242946, type: 3}
       insertIndex: 5
       addedObject: {fileID: -1618584709856610350}
+    - targetCorrespondingSourceObject: {fileID: 6604268163913019920, guid: 1074344954d3b7643a55e2d4e4242946, type: 3}
+      insertIndex: 6
+      addedObject: {fileID: 6861961359413821304}
   m_SourcePrefab: {fileID: 100100000, guid: 1074344954d3b7643a55e2d4e4242946, type: 3}
 --- !u!1 &8039956180917215674 stripped
 GameObject:
@@ -126,3 +129,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1c220cec5d8ca6b46b5f06d205e76dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &6861961359413821304
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8039956180917215674}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b336e2e421046e498eb2e3bfcfb8687, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  healthAmount: 100

--- a/Assets/Prefabs/ZombieUnit.prefab
+++ b/Assets/Prefabs/ZombieUnit.prefab
@@ -78,12 +78,6 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 6604268163913019920, guid: 1074344954d3b7643a55e2d4e4242946, type: 3}
       insertIndex: 4
       addedObject: {fileID: 1560776592699218487}
-    - targetCorrespondingSourceObject: {fileID: 6604268163913019920, guid: 1074344954d3b7643a55e2d4e4242946, type: 3}
-      insertIndex: 5
-      addedObject: {fileID: -1618584709856610350}
-    - targetCorrespondingSourceObject: {fileID: 6604268163913019920, guid: 1074344954d3b7643a55e2d4e4242946, type: 3}
-      insertIndex: 6
-      addedObject: {fileID: 6861961359413821304}
   m_SourcePrefab: {fileID: 100100000, guid: 1074344954d3b7643a55e2d4e4242946, type: 3}
 --- !u!1 &8039956180917215674 stripped
 GameObject:
@@ -117,28 +111,3 @@ MonoBehaviour:
   range: 5
   targetFaction: 0
   timerMax: 0.2
---- !u!114 &-1618584709856610350
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8039956180917215674}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1c220cec5d8ca6b46b5f06d205e76dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &6861961359413821304
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8039956180917215674}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b336e2e421046e498eb2e3bfcfb8687, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  healthAmount: 100

--- a/Assets/Scripts/Authoring/HealthAuthoring.cs
+++ b/Assets/Scripts/Authoring/HealthAuthoring.cs
@@ -1,0 +1,24 @@
+using Unity.Entities;
+using UnityEngine;
+
+public class HealthAuthoring : MonoBehaviour
+{
+    public int healthAmount;
+    
+    public class Baker : Baker<HealthAuthoring>
+    {
+        public override void Bake(HealthAuthoring authoring)
+        {
+            Entity entity = GetEntity(TransformUsageFlags.Dynamic);
+            AddComponent(entity, new Health
+            {
+                healthAmount = authoring.healthAmount,
+            });
+        }
+    }
+}
+
+public struct Health : IComponentData
+{
+    public int healthAmount;
+}

--- a/Assets/Scripts/Authoring/HealthAuthoring.cs.meta
+++ b/Assets/Scripts/Authoring/HealthAuthoring.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4b336e2e421046e498eb2e3bfcfb8687

--- a/Assets/Scripts/Systems/HealthDeadTestSystem.cs
+++ b/Assets/Scripts/Systems/HealthDeadTestSystem.cs
@@ -1,0 +1,44 @@
+using Unity.Burst;
+using Unity.Entities;
+
+[UpdateInGroup(typeof(LateSimulationSystemGroup))]
+partial struct HealthDeadTestSystem : ISystem
+{
+    // destroying the entity using `EntityCommandBuffer`
+    // entityCommandBuffer.DestroyEntity(entity); will not destroying the entity when we call this, but it will just add in the queue buffer
+    
+    [BurstCompile]
+    public void OnUpdate(ref SystemState state)
+    {
+        EntityCommandBuffer entityCommandBuffer = SystemAPI
+            .GetSingleton<EndSimulationEntityCommandBufferSystem.Singleton>().CreateCommandBuffer(state.WorldUnmanaged);
+        
+        foreach ((RefRO<Health> health, Entity entity) in SystemAPI.Query<RefRO<Health>>().WithEntityAccess())
+        {
+            if (health.ValueRO.healthAmount <= 0)
+            {
+                UnityEngine.Debug.Log($"Entity {entity} is dead");
+                entityCommandBuffer.DestroyEntity(entity);
+            }
+        }
+    }
+    
+    // NOTE : this code is without using the `EntityCommandBuffer`
+    // second, `WithEntityAccess` is used to get the entity reference from the query of the component, 
+    // like in this case we are using `RefRO<Health>` to get the entity reference
+    // third, to destroy the entity, we need to use `state.EntityManager.DestroyEntity(entity)` to destroy the entity
+    // but if we use `state.EntityManager.DestroyEntity(entity)` inside the `OnUpdate` method, it will throw an error
+    // InvalidOperationException: System.InvalidOperationException: Structural changes are not allowed while iterating over entities. Please use EntityCommandBuffer instead.
+    // [BurstCompile]
+    // public void OnUpdate(ref SystemState state)
+    // {
+    //     foreach ((RefRO<Health> health, Entity entity) in SystemAPI.Query<RefRO<Health>>().WithEntityAccess())
+    //     {
+    //         if (health.ValueRO.healthAmount <= 0)
+    //         {
+    //             UnityEngine.Debug.Log($"Entity {entity} is dead");
+    //             state.EntityManager.DestroyEntity(entity);
+    //         }
+    //     }   
+    // }
+}

--- a/Assets/Scripts/Systems/HealthDeadTestSystem.cs.meta
+++ b/Assets/Scripts/Systems/HealthDeadTestSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1648400cadaeb2442aa422bda9b93156

--- a/Assets/Scripts/Systems/ResetTargetSystem.cs
+++ b/Assets/Scripts/Systems/ResetTargetSystem.cs
@@ -1,0 +1,26 @@
+using Unity.Burst;
+using Unity.Entities;
+
+/// <summary>
+/// We need this `ResetTargetSystem` because when we destroy the entity, we are getting the following error:
+/// ArgumentException: The entity does not exist. Entities Journaling may be able to help determine more information. Please enable Entities Journaling for a more helpful error message.
+/// because in `ShootAttackSystem`, we are still trying to reduce the health from target entity, which is no longer exist anymore
+/// so for the solution, we need to reset the target entity to `Entity.Null` after every health system check
+/// that's why we are using `UpdateInGroup(typeof(LateSimulationSystemGroup))` so it will run after `HealthDeadTestSystem`
+/// </summary>
+
+[UpdateInGroup(typeof(LateSimulationSystemGroup))]
+partial struct ResetTargetSystem : ISystem
+{
+    [BurstCompile]
+    public void OnUpdate(ref SystemState state)
+    {
+        foreach (RefRW<Target> target in SystemAPI.Query<RefRW<Target>>())
+        {
+            if (!SystemAPI.Exists(target.ValueRO.targetEntity))
+            {
+                target.ValueRW.targetEntity = Entity.Null;    
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/ResetTargetSystem.cs.meta
+++ b/Assets/Scripts/Systems/ResetTargetSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 88aab8470b236104590224b3fe8b2a1e

--- a/Assets/Scripts/Systems/ShootAttackSystem.cs
+++ b/Assets/Scripts/Systems/ShootAttackSystem.cs
@@ -19,7 +19,11 @@ partial struct ShootAttackSystem : ISystem
                 continue;
             }
             shootAttack.ValueRW.timer = shootAttack.ValueRO.timerMax;
-            UnityEngine.Debug.Log($"Shoot attack damage to {target.ValueRO.targetEntity}");
+            //UnityEngine.Debug.Log($"Shoot attack damage to {target.ValueRO.targetEntity}");
+            
+            RefRW<Health> targetHealth = SystemAPI.GetComponentRW<Health>(target.ValueRO.targetEntity);
+            int damageAmount = 1;
+            targetHealth.ValueRW.healthAmount -= damageAmount;
         }
     }
 }


### PR DESCRIPTION
## Description

- add the heath Component in `Base` Unit Prefab
- reducing the health of the target entity, in `ShootAttackSystem`
- Write `HealthDeadTestSystem` to destroy the entity when its health reduced to 0, using `EntityCommandBuffer`
- Write `ResetTargetSystem` to make the entity `Null`, when its destroyed.

## Screenshots
- we need to attach `Linked Entity Group Authoring` Component to `BaseUnit` prefab, because when we destroy the `Entity` it were just destroy the entity, but not the mesh in child component.
<img width="354" alt="image" src="https://github.com/user-attachments/assets/6f3c9e0e-91f9-4c07-ba66-5b314590a0dd" />
