### PR TITLE
[ECS-20] Add shoot lighting when shoot

### DIFF
--- a/Assets/Prefabs/ShootLight.prefab
+++ b/Assets/Prefabs/ShootLight.prefab
@@ -1,0 +1,137 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &9063414758300489506
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5154950029833856825}
+  - component: {fileID: 3681900235032693767}
+  - component: {fileID: 30696908185021111}
+  - component: {fileID: 3024818594383640161}
+  m_Layer: 0
+  m_Name: ShootLight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5154950029833856825
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9063414758300489506}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 2.23, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!108 &3681900235032693767
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9063414758300489506}
+  m_Enabled: 1
+  serializedVersion: 11
+  m_Type: 2
+  m_Color: {r: 1, g: 0.8993666, b: 0.23529412, a: 1}
+  m_Intensity: 20
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 1
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+  m_LightUnit: 1
+  m_LuxAtDistance: 1
+  m_EnableSpotReflector: 1
+--- !u!114 &30696908185021111
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9063414758300489506}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 0
+  m_LightLayerMask: 1
+  m_RenderingLayers: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
+--- !u!114 &3024818594383640161
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9063414758300489506}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d008fc0a7ef36b14c9cc37aa9e866a2d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  timer: 0.05

--- a/Assets/Prefabs/ShootLight.prefab.meta
+++ b/Assets/Prefabs/ShootLight.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 03532d9dfc8e35744b553fddf44ae7cd
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -20,7 +20,7 @@ RenderSettings:
   m_FogDensity: 0.01
   m_LinearFogStart: 0
   m_LinearFogEnd: 300
-  m_AmbientSkyColor: {r: 0.87058824, g: 0.87058824, b: 0.87058824, a: 1}
+  m_AmbientSkyColor: {r: 0, g: 0.77597976, b: 1, a: 1}
   m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
   m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
   m_AmbientIntensity: 1

--- a/Assets/Scenes/GameScene/EntitiesSubScene.unity
+++ b/Assets/Scenes/GameScene/EntitiesSubScene.unity
@@ -197,6 +197,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   bulletPrefab: {fileID: 3255267315999589856, guid: 1d20c115a3da9fd42a3f014ccd2c527f, type: 3}
   zombiePrefab: {fileID: 8039956180917215674, guid: 29862828c4ea86546867f5aac1cb5ccd, type: 3}
+  shootLightPrefab: {fileID: 9063414758300489506, guid: 03532d9dfc8e35744b553fddf44ae7cd, type: 3}
 --- !u!4 &219763539
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Authoring/EntitiesReferencesAuthoring.cs
+++ b/Assets/Scripts/Authoring/EntitiesReferencesAuthoring.cs
@@ -4,6 +4,7 @@ public class EntitiesReferencesAuthoring : MonoBehaviour
 {
     public GameObject bulletPrefab;
     public GameObject zombiePrefab;
+    public GameObject shootLightPrefab;
     
     public class Baker : Baker<EntitiesReferencesAuthoring>
     {
@@ -13,7 +14,8 @@ public class EntitiesReferencesAuthoring : MonoBehaviour
             AddComponent(entity, new EntitiesReferences
             {
                 bulletPrefabEntity = GetEntity(authoring.bulletPrefab, TransformUsageFlags.Dynamic),
-                zombiePrefabEntity = GetEntity(authoring.zombiePrefab, TransformUsageFlags.Dynamic)
+                zombiePrefabEntity = GetEntity(authoring.zombiePrefab, TransformUsageFlags.Dynamic),
+                shootLightPrefabEntity = GetEntity(authoring.shootLightPrefab, TransformUsageFlags.Dynamic)
             });
         }
     }
@@ -23,4 +25,5 @@ public struct EntitiesReferences : IComponentData
 {
     public Entity bulletPrefabEntity;
     public Entity zombiePrefabEntity;
+    public Entity shootLightPrefabEntity;
 }

--- a/Assets/Scripts/Authoring/ShootAttackAuthoring.cs
+++ b/Assets/Scripts/Authoring/ShootAttackAuthoring.cs
@@ -29,4 +29,11 @@ public struct ShootAttack : IComponentData
     public float timerMax;
     public float attackDistance;
     public float3 bulletSpawnLocalPosition;
+    public OnShootEvent onShoot;
+
+    public struct OnShootEvent
+    {
+        public bool isTriggered;
+        public float3 shootFromPosition;
+    }
 }

--- a/Assets/Scripts/Authoring/ShootLightAuthoring.cs
+++ b/Assets/Scripts/Authoring/ShootLightAuthoring.cs
@@ -1,0 +1,23 @@
+using Unity.Entities;
+using UnityEngine;
+
+public class ShootLightAuthoring : MonoBehaviour
+{
+    public float timer;
+    public class Baker : Baker<ShootLightAuthoring>
+    {
+        public override void Bake(ShootLightAuthoring authoring)
+        {
+            Entity entity = GetEntity(TransformUsageFlags.Dynamic);
+            AddComponent(entity, new ShootLight
+            {
+                timer = authoring.timer
+            });
+        }
+    }
+}
+
+public struct ShootLight : IComponentData
+{
+    public float timer; 
+}

--- a/Assets/Scripts/Authoring/ShootLightAuthoring.cs.meta
+++ b/Assets/Scripts/Authoring/ShootLightAuthoring.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d008fc0a7ef36b14c9cc37aa9e866a2d

--- a/Assets/Scripts/Systems/HealthBarSystem.cs
+++ b/Assets/Scripts/Systems/HealthBarSystem.cs
@@ -37,7 +37,6 @@ partial struct HealthBarSystem : ISystem
             
             float healthNormalized = (float)health.healthAmount / health.healthAmountMax;
             localTransform.ValueRW.Scale = healthNormalized == 1f ? 0f : 1f;
-            Debug.Log($"health visual update : {health.healthAmount}");
             
             // NOTE : we cant use `RefRW<LocalTransform>` to set the scale, because scale is float instead of float3, which will set the scale uniformly in all directions.
             // in the health bar, we want to set only in x direction to set the bar

--- a/Assets/Scripts/Systems/ResetEventsSystem.cs
+++ b/Assets/Scripts/Systems/ResetEventsSystem.cs
@@ -17,5 +17,10 @@ partial struct ResetEventsSystem : ISystem
         {
             health.ValueRW.onHealthChanged = false;
         }
+        
+        foreach(RefRW<ShootAttack> shootAttack in SystemAPI.Query<RefRW<ShootAttack>>())
+        {
+            shootAttack.ValueRW.onShoot.isTriggered = false;
+        }
     }
 }

--- a/Assets/Scripts/Systems/ShootAttackSystem.cs
+++ b/Assets/Scripts/Systems/ShootAttackSystem.cs
@@ -59,6 +59,10 @@ partial struct ShootAttackSystem : ISystem
 
             RefRW<Target> bulletTargetComp = SystemAPI.GetComponentRW<Target>(bulletEntity);
             bulletTargetComp.ValueRW.targetEntity = target.ValueRO.targetEntity;
+
+            shootAttack.ValueRW.onShoot.isTriggered = true;
+            shootAttack.ValueRW.onShoot.shootFromPosition = bulletSpawnWorldPosition;
+
         }
     }
 }

--- a/Assets/Scripts/Systems/ShootLightDestroySystem.cs
+++ b/Assets/Scripts/Systems/ShootLightDestroySystem.cs
@@ -1,0 +1,24 @@
+using Unity.Burst;
+using Unity.Entities;
+
+partial struct ShootLightDestroySystem : ISystem
+{
+    [BurstCompile]
+    public void OnUpdate(ref SystemState state)
+    {
+        EntityCommandBuffer entityCommandBuffer = SystemAPI
+            .GetSingleton<EndSimulationEntityCommandBufferSystem.Singleton>().CreateCommandBuffer(state.WorldUnmanaged);
+        
+        foreach ((RefRW<ShootLight> shootLight, Entity entity) in 
+                 SystemAPI.Query<RefRW<ShootLight>>().WithEntityAccess())
+        {
+            shootLight.ValueRW.timer -= SystemAPI.Time.DeltaTime;
+            if (shootLight.ValueRO.timer <= 0)
+            {
+                entityCommandBuffer.DestroyEntity(entity);    
+            }
+        }    
+    }
+
+    
+}

--- a/Assets/Scripts/Systems/ShootLightDestroySystem.cs.meta
+++ b/Assets/Scripts/Systems/ShootLightDestroySystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4c575ab63531a0c4db9be9329a4a7517

--- a/Assets/Scripts/Systems/ShootLightSpawnerSystem.cs
+++ b/Assets/Scripts/Systems/ShootLightSpawnerSystem.cs
@@ -1,0 +1,23 @@
+using Unity.Burst;
+using Unity.Entities;
+using Unity.Transforms;
+
+[UpdateInGroup(typeof(LateSimulationSystemGroup))]
+partial struct ShootLightSpawnerSystem : ISystem
+{
+    [BurstCompile]
+    public void OnUpdate(ref SystemState state)
+    {
+        EntitiesReferences entitiesReferences = SystemAPI.GetSingleton<EntitiesReferences>();
+        
+        foreach (RefRO<ShootAttack> shootAttack in SystemAPI.Query<RefRO<ShootAttack>>())
+        {
+            if(shootAttack.ValueRO.onShoot.isTriggered)
+            {
+                // spawn shoot light
+                Entity shootLightEntity = state.EntityManager.Instantiate(entitiesReferences.shootLightPrefabEntity);
+                SystemAPI.SetComponent(shootLightEntity, LocalTransform.FromPosition(shootAttack.ValueRO.onShoot.shootFromPosition));
+            }
+        }   
+    }
+}

--- a/Assets/Scripts/Systems/ShootLightSpawnerSystem.cs.meta
+++ b/Assets/Scripts/Systems/ShootLightSpawnerSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ca34f1c347a44b34eb02abf4ae89b9a2

--- a/Assets/Settings/PC_RPAsset.asset
+++ b/Assets/Settings/PC_RPAsset.asset
@@ -43,7 +43,7 @@ MonoBehaviour:
   m_ProbeVolumeSHBands: 1
   m_MainLightRenderingMode: 1
   m_MainLightShadowsSupported: 1
-  m_MainLightShadowmapResolution: 2048
+  m_MainLightShadowmapResolution: 4096
   m_AdditionalLightsRenderingMode: 1
   m_AdditionalLightsPerObjectLimit: 4
   m_AdditionalLightShadowsSupported: 1


### PR DESCRIPTION
## Description
- add Prefab of `ShootLight`, which is a point light.
- Add `ShootLightSpawnerSystem`, which is actually a event listener, when we shoot to target, we fire an event called `onShoot`, which is listen by `ShootLightSpawnerSystem` to instantiate the `ShootLight` prefab
- Add `ShootLightDestroySystem` which is responsible to destroy the `ShootLight` prefab after certain period of time.

## Screenshots
<img width="284" alt="image" src="https://github.com/user-attachments/assets/c1c77298-a22a-428d-9a6b-ed264756e368" />
